### PR TITLE
Fix jumbotron image to be responsive

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -96,6 +96,15 @@
     background-repeat: no-repeat;
     z-index: -1;
     top: 0 !important;
+    @media (min-width: 1300px) and (max-width: 1523px) {
+      height: 25em;
+    }
+    @media (min-width: 968px) and (max-width: 1300px) {
+      height: 20em;
+    }
+    @media (max-width: 968px) {
+      height: 15em;
+    }
 }
 
 .block.block-block-95 {


### PR DESCRIPTION
This adds a responsive css to the jumbotron so the white space beneath the search bar is eliminated