### PR TITLE
Update development oauth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@
 /node_modules
 application.yml
 figaro
+server.crt
+server.csr
+server.key
+server.orig.key

--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem 'faraday'
 gem 'faker'
 gem 'react-rails'
 gem 'omniauth-oauth2'
-gem 'omniauth-census', git: "https://github.com/turingschool-projects/omniauth-census.git"
+gem 'omniauth-census', git: "https://github.com/NZenitram/census_staging_oauth"
 gem 'thin'
 gem 'axios_rails', '~> 0.7.0'
 gem "responders"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
-  remote: https://github.com/turingschool-projects/omniauth-census.git
-  revision: 3d28a5040e79eae620c3550b90e94aeed8234571
+  remote: https://github.com/NZenitram/census_staging_oauth
+  revision: 082f9c376dd85e6d65415f8d1dac0e054971433c
   specs:
     omniauth-census (0.1.1)
       omniauth-oauth2
@@ -377,4 +377,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.13.7
+   1.14.6

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,6 @@ class User < ApplicationRecord
   end
 
   def self.create_from_census(user_info)
-		require "pry"; binding.pry
     user = find_or_initialize_by(uid: user_info["uid"])
 
     user.first_name = user_info.info["first_name"]


### PR DESCRIPTION
@drod1000 @Laszlo-JFLMTCO @mollybrown  The Oauth for the development on localhost is working now. Just a quick update on what was done. in the gemfile I updated 
```gem 'omniauth-census', git: "https://github.com/turingschool-projects/omniauth-census.git"``` to 
```gem 'omniauth-census', git: "https://github.com/NZenitram/census_staging_oauth"```

Visit https://github.com/NZenitram/census_staging_oauth and follow the walkthrough of setting up the gem thin. You don't need to install it as it is already in our Gemfile. I don't know if it's the norm but for Daniel and I it didn't work on chrome but I found that after this I was able to go through the oauth in development on Safari. 

For reference sake so we know what we are working with I took a picture of what the information looks like coming in from census so we can utilize this to help populate things where we are able to.
 
![image](https://cloud.githubusercontent.com/assets/18131669/24525651/541fe280-1558-11e7-873f-2819f7a8a8f4.png)

@neight-allen 