### PR TITLE
142735009 remove logged in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,8 +7,4 @@ class ApplicationController < ActionController::Base
   def current_user
     @current_user ||= User.find(session[:user_id]) if session[:user_id]
   end
-
-  def logged_in?
-    current_user
-  end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,6 +1,6 @@
 class DashboardController < ApplicationController
   def index
-    if (logged_in?)
+    if (current_user)
       @dashboard_presenter = DashboardPresenter.new(current_user)
     else
       redirect_to root_path


### PR DESCRIPTION
@drod1000 @mollybrown @Laszlo-JFLMTCO 

This PR closes issue #142735009 for removing the logged in method. It was a quick and easy pulling out a method and referencing current_user instead of logged_in? in another method. Ran tests and nothing broke. This PR probably only needs one set of eyes.