### PR TITLE
143349107 remove user portfolio path

### DIFF
--- a/app/controllers/users/portfolios_controller.rb
+++ b/app/controllers/users/portfolios_controller.rb
@@ -1,9 +1,5 @@
 class Users::PortfoliosController < ApplicationController
 
-  def show
-    @user = User.find_by(slug: params["user_slug"])
-  end
-
   def new
     @user = current_user
     @locations = Location.distinct_city_states

--- a/app/views/users/portfolios/show.html.erb
+++ b/app/views/users/portfolios/show.html.erb
@@ -1,1 +1,0 @@
-<%= react_component('PortfolioShow', {user: @user, portfolio: @user.portfolio, projects: @user.projects, slug: @user.slug}, {prerender: true}) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
 
   resources :users, only: [:edit, :update] do
     get 'edit-account', to: 'users#account'
-    resource :portfolio, :controller => "users/portfolios" do
+    resource :portfolio, :controller => "users/portfolios", except: [:show] do
       get '/delete', to: "users/portfolios#delete"
     end
     resource :project, :controller => "users/projects", only: [:new, :create, :edit, :update, :destroy]


### PR DESCRIPTION
@jdconrad89 @mollybrown @Laszlo-JFLMTCO 
Removes user portfolio show from routes, controller, and views since the dashboards controller displays the user's portfolio.

Quick side note, it looks like dashboard index is what leads to a user's profile. Wouldn't a show action be more appropriate? Let me know what you all think and I can create an issue or take care of it on this PR.

@neight-allen 